### PR TITLE
Update runtime and SDK versions in YAML config

### DIFF
--- a/org.openfodder.OpenFodder.yml
+++ b/org.openfodder.OpenFodder.yml
@@ -1,12 +1,12 @@
 app-id: org.openfodder.OpenFodder
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
-  - org.freedesktop.Sdk.Extension.llvm16
+  - org.freedesktop.Sdk.Extension.llvm21
 build-options:
-  append-path: /usr/lib/sdk/llvm16/bin
-  prepend-ld-library-path: /usr/lib/sdk/llvm16/lib
+  append-path: /usr/lib/sdk/llvm12/bin
+  prepend-ld-library-path: /usr/lib/sdk/llvm21/lib
 command: openfodder
 finish-args:
   - --socket=x11
@@ -22,7 +22,7 @@ modules:
       - type: git
         url: https://github.com/OpenFodder/openfodder.git
         tag: 1.9.2
-        commit: 189fa1c3e17570ed49f1442918c7f97fcec7b5d7
+        commit: 162a68f9ce927ccb90ad336372c52d909dbdece4
         x-checker-data:
           type: git
           tag-pattern: ^([\d.]+)$
@@ -42,7 +42,7 @@ modules:
       - install -Dm644 org.openfodder.OpenFodder.appdata.xml -t ${FLATPAK_DEST}/share/metainfo/
       - install -Dm644 org.openfodder.OpenFodder.desktop -t ${FLATPAK_DEST}/share/applications/
       - install -Dm644 org.openfodder.OpenFodder.png -t ${FLATPAK_DEST}/share/icons/hicolor/128x128/apps/
-
+  # The below doesn't seem to be used anywhere, so the data zip is never downloaded or extracted - it is compiled into the sandbox at build time above - but leaving just in case
   - name: data
     buildsystem: simple
     build-commands:

--- a/org.openfodder.OpenFodder.yml
+++ b/org.openfodder.OpenFodder.yml
@@ -42,7 +42,6 @@ modules:
       - install -Dm644 org.openfodder.OpenFodder.appdata.xml -t ${FLATPAK_DEST}/share/metainfo/
       - install -Dm644 org.openfodder.OpenFodder.desktop -t ${FLATPAK_DEST}/share/applications/
       - install -Dm644 org.openfodder.OpenFodder.png -t ${FLATPAK_DEST}/share/icons/hicolor/128x128/apps/
-  # The below doesn't seem to be used anywhere, so the data zip is never downloaded or extracted - it is compiled into the sandbox at build time above - but leaving just in case
   - name: data
     buildsystem: simple
     build-commands:

--- a/org.openfodder.OpenFodder.yml
+++ b/org.openfodder.OpenFodder.yml
@@ -5,7 +5,7 @@ sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.llvm21
 build-options:
-  append-path: /usr/lib/sdk/llvm12/bin
+  append-path: /usr/lib/sdk/llvm21/bin
   prepend-ld-library-path: /usr/lib/sdk/llvm21/lib
 command: openfodder
 finish-args:
@@ -21,7 +21,6 @@ modules:
     sources:
       - type: git
         url: https://github.com/OpenFodder/openfodder.git
-        tag: 1.9.2
         commit: 162a68f9ce927ccb90ad336372c52d909dbdece4
         x-checker-data:
           type: git

--- a/org.openfodder.OpenFodder.yml
+++ b/org.openfodder.OpenFodder.yml
@@ -21,7 +21,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/OpenFodder/openfodder.git
-        commit: 162a68f9ce927ccb90ad336372c52d909dbdece4
+        tag: 2.0.0
+        commit: 5eb41362f72fcedf2b1dffed397a7a8edf9a6305
         x-checker-data:
           type: git
           tag-pattern: ^([\d.]+)$


### PR DESCRIPTION
Update SDK as 23.08 is EOL
Update OpenFodder to latest commit which include Flatpak data directory improvement.
Add comment about data download and extraction routine which appears to never be called